### PR TITLE
[FEATURE] 팀 API 구현

### DIFF
--- a/src/main/java/kr/sporting/team/controller/TeamController.java
+++ b/src/main/java/kr/sporting/team/controller/TeamController.java
@@ -1,0 +1,53 @@
+package kr.sporting.team.controller;
+
+import jakarta.validation.Valid;
+import kr.sporting.team.domain.Team;
+import kr.sporting.team.dto.CreateTeamRequest;
+import kr.sporting.team.dto.UpdateTeamRequest;
+import kr.sporting.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamController {
+    private final TeamService teamService;
+
+    @GetMapping("/teams")
+    public ResponseEntity<Team> getTeams() {
+        teamService.getTeams();
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/teams/{id}")
+    public ResponseEntity<Team> getTeam(@PathVariable Long id) {
+        try {
+            Team team = teamService.getTeamById(id);
+            return ResponseEntity.ok(team);
+        } catch (Throwable e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/teams")
+    public ResponseEntity<Team> createTeam(@RequestBody @Valid CreateTeamRequest request) {
+        teamService.createTeam(request.toEntity());
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/teams/{id}")
+    public ResponseEntity<Team> updateTeam(@PathVariable Long id, @RequestBody @Valid UpdateTeamRequest request) {
+        teamService.updateTeam(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/teams/{id}")
+    public ResponseEntity<Team> deleteTeam(@PathVariable Long id) {
+        teamService.deleteTeam(id);
+        return ResponseEntity.ok().build();
+    }
+    
+}
+

--- a/src/main/java/kr/sporting/team/domain/Team.java
+++ b/src/main/java/kr/sporting/team/domain/Team.java
@@ -1,0 +1,42 @@
+package kr.sporting.team.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.List;
+@EntityListeners(AuditingEntityListener.class)
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity(name = "sporting_team")
+public class Team {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "team_name", nullable = false)
+    @NotBlank
+    private String teamName;
+
+    @Column(name = "address", nullable = false)
+    @NotBlank
+    private String address;
+
+    @Transient
+    @Column(name = "records", nullable = false)
+    private List<Object> records;
+
+    @Transient
+//    @ManyToMany
+//    @JoinColumn(name = "member_id", referencedColumnName = "id") // member 구현 후 foreign key로 대체
+    private Object member; // 'Object'는 나중에 Member로 변경
+
+    @Column(name = "team_size", nullable = false)
+    private Integer teamSize;
+
+}

--- a/src/main/java/kr/sporting/team/dto/CreateTeamRequest.java
+++ b/src/main/java/kr/sporting/team/dto/CreateTeamRequest.java
@@ -1,0 +1,40 @@
+package kr.sporting.team.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.sporting.team.domain.Team;
+import lombok.*;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@Schema(description = "팀 생성")
+public class CreateTeamRequest {
+
+    @NotBlank(message = "팀 이름은 필수 입력값입니다.")
+    @Schema(description = "팀 이름")
+    private String teamName;
+
+    @NotBlank(message = "주소는 필수 입력값입니다.")
+    @Schema(description = "팀 지역")
+    private String address;
+
+    @NotNull(message = "최대 멤버 수는 필수 입력값입니다.")
+    @Min(value = 2, message = "최대 팀원 수는 1보다 커야합니다.")
+    @Schema(description = "팀 최대 인원")
+    private Integer teamSize;
+
+    public Team toEntity() {
+        return Team.builder()
+                .teamName(this.teamName)
+                .address(this.address)
+                .teamSize(this.teamSize)
+                .build();
+    }
+}

--- a/src/main/java/kr/sporting/team/dto/UpdateTeamRequest.java
+++ b/src/main/java/kr/sporting/team/dto/UpdateTeamRequest.java
@@ -1,0 +1,30 @@
+package kr.sporting.team.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@Schema(description = "팀 수정")
+public class UpdateTeamRequest {
+
+    @NotBlank(message = "팀 이름은 필수 입력값입니다.")
+    @Schema(description = "팀 이름", nullable = true)
+    private String teamName;
+
+    @NotBlank(message = "주소는 필수 입력값입니다.")
+    @Schema(description = "팀 주소", nullable = true)
+    private String address;
+
+    @NotNull(message = "최대 멤버 수는 필수 입력값입니다.")
+    @Min(value = 2, message = "최대 팀원 수는 1보다 커야합니다.")
+    @Schema(description = "팀 최대 인원", nullable = true)
+    private Integer teamSize;
+}

--- a/src/main/java/kr/sporting/team/exception/TeamNotFoundException.java
+++ b/src/main/java/kr/sporting/team/exception/TeamNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.sporting.team.exception;
+
+public class TeamNotFoundException extends RuntimeException {
+    public TeamNotFoundException() {
+        super("Team not found with the provided ID.");
+    }
+
+    public TeamNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/sporting/team/repository/TeamRepository.java
+++ b/src/main/java/kr/sporting/team/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package kr.sporting.team.repository;
+
+import kr.sporting.team.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/kr/sporting/team/service/TeamService.java
+++ b/src/main/java/kr/sporting/team/service/TeamService.java
@@ -1,0 +1,61 @@
+package kr.sporting.team.service;
+
+import kr.sporting.team.domain.Team;
+import kr.sporting.team.dto.UpdateTeamRequest;
+import kr.sporting.team.exception.TeamNotFoundException;
+import kr.sporting.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Service
+public class TeamService {
+    private final TeamRepository teamRepository;
+
+    @Transactional
+    public Team createTeam(Team team) {
+        teamRepository.save(team);
+        return (team);
+    }
+
+    @Transactional
+    public void deleteTeam(Long teamId) {
+        teamRepository.deleteById(teamId);
+    }
+
+    @Transactional
+    public Team updateTeam(Long teamId, UpdateTeamRequest request) {
+        Team team = teamRepository.findById(teamId).orElseThrow(TeamNotFoundException::new);
+
+        if (request.getTeamName() != null) {
+            team.setTeamName(request.getTeamName());
+        }
+
+        if (request.getAddress() != null) {
+            team.setAddress(request.getAddress());
+        }
+
+        if (request.getTeamSize() != null) {
+            team.setTeamSize(request.getTeamSize());
+        }
+
+        teamRepository.save(team);
+        return (team);
+    }
+
+    @Transactional(readOnly = true)
+    public Iterable<Team> getTeams() {
+        return teamRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Team getTeamById(Long id) {
+        return (teamRepository
+                .findById(id)
+                .orElseThrow(TeamNotFoundException::new));
+    }
+}
+
+

--- a/src/test/java/kr/sporting/team/TeamRepositoryTest.java
+++ b/src/test/java/kr/sporting/team/TeamRepositoryTest.java
@@ -1,0 +1,81 @@
+package kr.sporting.team;
+
+import kr.sporting.team.domain.Team;
+import kr.sporting.team.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataJpaTest
+class TeamRepositoryTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @BeforeEach
+    void setUp() {
+        teamRepository.save(Team.builder()
+                .teamName("Lakers")
+                .address("Los Angeles")
+                .teamSize(15) // 필수 컬럼 값을 지정
+                .build());
+        teamRepository.save(Team.builder()
+                .teamName("Warriors")
+                .address("San Francisco")
+                .teamSize(12) // 필수 컬럼 값을 지정
+                .build());
+    }
+
+    @Test
+    void testFindAll_ReturnsAllTeams() {
+        List<Team> teams = teamRepository.findAll();
+        assertThat(teams).hasSize(2);
+    }
+
+    @Test
+    void testSave_PersistsTeam() {
+        Team team = Team.builder()
+                .teamName("Bulls")
+                .address("Chicago")
+                .teamSize(14) // 필수 컬럼 값을 지정
+                .build();
+        Team savedTeam = teamRepository.save(team);
+
+        assertThat(savedTeam.getId()).isNotNull();
+        assertThat(savedTeam.getTeamName()).isEqualTo("Bulls");
+        assertThat(savedTeam.getAddress()).isEqualTo("Chicago");
+    }
+
+    @Test
+    void testFindById_ReturnsTeam() {
+        Team team = teamRepository.save(Team.builder()
+                .teamName("Celtics")
+                .address("Boston")
+                .teamSize(10) // 필수 컬럼 값을 지정
+                .build());
+        Team foundTeam = teamRepository.findById(team.getId()).orElse(null);
+
+        assertThat(foundTeam).isNotNull();
+        assertThat(foundTeam.getTeamName()).isEqualTo("Celtics");
+        assertThat(foundTeam.getAddress()).isEqualTo("Boston");
+    }
+
+    @Test
+    void testDelete_RemovesTeam() {
+        Team team = teamRepository.save(Team.builder()
+                .teamName("Nets")
+                .address("Brooklyn")
+                .teamSize(9) // 필수 컬럼 값을 지정
+                .build());
+
+        teamRepository.delete(team);
+
+        assertThat(teamRepository.findById(team.getId())).isEmpty();
+    }
+}

--- a/src/test/java/kr/sporting/team/TeamServiceTest.java
+++ b/src/test/java/kr/sporting/team/TeamServiceTest.java
@@ -1,0 +1,100 @@
+package kr.sporting.team;
+
+import kr.sporting.team.repository.TeamRepository;
+import kr.sporting.team.domain.Team;
+import kr.sporting.team.service.TeamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class TeamServiceTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamService teamService;
+
+    @BeforeEach
+    void setUp() {
+        teamRepository.deleteAll();
+    }
+
+    @Test
+    void testCreateTeam_SavesAndReturnsTeam() {
+        // 필수 필드 포함
+        Team team = new Team();
+        team.setTeamName("Celtics");
+        team.setAddress("Boston");
+        team.setTeamSize(10);
+
+        Team createdTeam = teamService.createTeam(team);
+
+        assertThat(createdTeam.getTeamName()).isEqualTo("Celtics");
+        assertThat(createdTeam.getAddress()).isEqualTo("Boston");
+    }
+
+    @Test
+    void testGetTeamById_ReturnsTeam() {
+        Team team = Team.builder()
+                .teamName("Lakers")
+                .address("Los Angeles")
+                .teamSize(15)
+                .build();
+
+        Team result = teamRepository.save(team);
+        Team foundTeam = teamService.getTeamById(result.getId());
+
+        assertThat(foundTeam.getTeamName()).isEqualTo("Lakers");
+        assertThat(foundTeam.getAddress()).isEqualTo("Los Angeles");
+    }
+
+    @Test
+    void testGetTeamById_ThrowsExceptionWhenNotFound() {
+        assertThrows(RuntimeException.class, () -> teamService.getTeamById(1L));
+    }
+
+    @Test
+    void testGetAllTeams_ReturnsAllTeams() {
+        Team team1 = Team.builder()
+                .teamName("Lakers")
+                .address("Los Angeles")
+                .teamSize(15)
+                .build();
+        Team team2 = Team.builder()
+                .teamName("Warriors")
+                .address("San Francisco")
+                .teamSize(12)
+                .build();
+
+        teamRepository.saveAll(Arrays.asList(team1, team2));
+
+        assertThat(teamService.getTeams()).hasSize(2)
+                .extracting(Team::getTeamName)
+                .containsExactly("Lakers", "Warriors");
+    }
+
+    @Test
+    void testDeleteTeam_DeletesTeam() {
+        Team team1 = Team.builder()
+                .teamName("Lakers")
+                .address("Los Angeles")
+                .teamSize(15)
+                .build();
+
+        teamRepository.save(team1);
+
+        teamService.deleteTeam(1L);
+
+        assertThrows(RuntimeException.class, () -> teamService.getTeamById(1L));
+    }
+}


### PR DESCRIPTION
## 설명
Team 기능 구현하였습니다.
- Team 엔티티
- 단일, 전체 엔티티 조회
- 엔티티 생성, 수정, 삭제

## 비고
dto의 필드가 유효한지 확인하기 위해 spring-boot-starter-validation가 필요하지만, #4 에 추가되어 있어 build.gradle.kts에 추가하지 않았습니다. 
User 엔티티가 머지되지 않아 member필드를 임시로 Object 타입으로 두고,
전적은 매칭 관련 기능을 구현하고 추후에 타입을 바꿔야 될 것 같다고 판단해 Object 타입으로 두었습니다.
두 필드 모두 db의 테이블에는 추가되지 않습니다.